### PR TITLE
Specify minimum perl version in cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'Mojolicious', '5.00';
 requires 'Digest::SHA';
 requires 'MIME::Base64', '3.11';
+requires 'perl', '5.006';
 
 recommends 'Crypt::OpenSSL::RSA';
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'Mojolicious', '5.00';
 requires 'Digest::SHA';
 requires 'MIME::Base64', '3.11';
-requires 'perl', '5.006';
+requires 'perl', '5.010';
 
 recommends 'Crypt::OpenSSL::RSA';
 


### PR DESCRIPTION
Mojo-JWT is my assigned dist for this month's [CPAN PR Challenge](http://cpan-prc.org) - thanks for participating.

This simple PR specifies 5.006 as the minimum version of perl in the cpanfile. It therefore fixes the only outstanding [kwalitee issue](https://cpants.cpanauthors.org/dist/Mojo-JWT).