### PR TITLE
Decode/verify with JWK

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Mojo::JWT
 
+NEXT
+  - Allow passing in a JWKSet which can be used for decoding/verifying tokens
+
 0.08 2018-12-03
   - Specify minimum perl version (openstrike, PRC)
 

--- a/README.pod
+++ b/README.pod
@@ -64,6 +64,14 @@ The symmetric secret (eg. HMAC) or else the private key used in encoding an asym
 
 If true (false by default), then the C<iat> claim will be set to the value of L</now> during L</encode>.
 
+=head2 jwkset
+
+An arrayref of JWK objects usec by C<decode_with_jwkset> to verify the input token.
+
+    my $jwkset = Mojo::UserAgent->get('https://example.com/oidc/jwks.json')->result->json;
+    my $jwt = Mojo::JWT->new(jwkset => $jwkset);
+    $jwk->decode_with_jwkset($token);
+
 =head1 METHODS
 
 L<Mojo::JWT> inherits all of the methods from L<Mojo::Base> and implements the following new ones.

--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'Digest::SHA';
 requires 'MIME::Base64', '3.11';
 requires 'perl', '5.010';
 
+recommends 'Crypt::OpenSSL::Bignum';
 recommends 'Crypt::OpenSSL::RSA';
 
 configure_requires 'Module::Build::Tiny';

--- a/lib/Mojo/JWT.pm
+++ b/lib/Mojo/JWT.pm
@@ -91,6 +91,8 @@ sub decode_with_jwkset {
     require Crypt::OpenSSL::Bignum;
     my $n = Crypt::OpenSSL::Bignum->new_from_bin(decode_base64url $jwk->{n});
     my $e = Crypt::OpenSSL::Bignum->new_from_bin(decode_base64url $jwk->{e});
+
+    require Crypt::OpenSSL::RSA;
     my $pubkey = Crypt::OpenSSL::RSA->new_key_from_parameters($n, $e);
     $self->public($pubkey);
   } elsif ($header->{alg} =~ /^HS/) {

--- a/lib/Mojo/JWT.pm
+++ b/lib/Mojo/JWT.pm
@@ -75,7 +75,7 @@ sub decode {
 
 sub decode_with_jwkset {
   my ($self, $token) = @_;
-  croak 'Missing JWKSet' unless $self->jwkset->@* > 0;
+  croak 'Missing JWKSet' unless @{$self->jwkset} > 0;
 
   my ($hstring) = split /\./, $token;
   my $header = decode_json decode_base64url($hstring);
@@ -84,7 +84,7 @@ sub decode_with_jwkset {
   croak 'Required header field "kid" not specified' unless $header->{kid};
 
   # Check we have the JWK for this JWT
-  my $jwk = first { exists $header->{kid} && $_->{kid} eq $header->{kid} } $self->jwkset->@*;
+  my $jwk = first { exists $header->{kid} && $_->{kid} eq $header->{kid} } @{$self->jwkset};
   croak "Missing JWK for key_id=$header->{kid}" unless $jwk;
 
   if ($header->{alg} =~ /^RS/) {

--- a/lib/Mojo/JWT.pm
+++ b/lib/Mojo/JWT.pm
@@ -227,6 +227,14 @@ The symmetric secret (eg. HMAC) or else the private key used in encoding an asym
 
 If true (false by default), then the C<iat> claim will be set to the value of L</now> during L</encode>.
 
+=head2 jwkset
+
+An arrayref of JWK objects usec by C<decode_with_jwkset> to verify the input token.
+
+    my $jwkset = Mojo::UserAgent->get('https://example.com/oidc/jwks.json')->result->json;
+    my $jwt = Mojo::JWT->new(jwkset => $jwkset);
+    $jwk->decode_with_jwkset($token);
+
 =head1 METHODS
 
 L<Mojo::JWT> inherits all of the methods from L<Mojo::Base> and implements the following new ones.


### PR DESCRIPTION
ref #6 

This contains a (very) basic implementation and test cases for decoding/verifying a JWT against a set of JWKs. Usage is along these lines:

```perl
my $ua = Mojo::UserAgent->new;
my $jwkset = $ua->get('https://example.com/oidc/jwks.json')->result->json;

my $jwt = Mojo::JWT->new(jwkset => $jwkset);
$jwt->decode_with_jwkset($token);
say Dumper($jwt->claims);
```

`decode_with_jwkset` just tries to find the appropriate JWK based on the `kid`, sets `public` or `secret` and then passes the actual handling off to `decode`. I intentionally put the requirement of fetching the JWKs to the user to avoid having to handle fetching, caching etc and keep this extremely simple.

Feedback/abuse welcome :)