### PR TITLE
Add support for ECC signatures by switching to Crypt::PK::*

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,8 @@ requires 'Digest::SHA';
 requires 'MIME::Base64', '3.11';
 requires 'perl', '5.010';
 
-recommends 'Crypt::OpenSSL::RSA';
+recommends 'Crypt::PK::RSA';
+recommends 'Crypt::PK::ECC';
 
 configure_requires 'Module::Build::Tiny';
 


### PR DESCRIPTION
There is no Crypt::OpenSSL::* module to support ECC signatures, which
the JWT standard specifies. As a result, this module currently does not
support ECC tokens, only HMAC and RSA ones.

Switch to Crypt::PK::* instead, which does have a ECC module that has
the exact same API as its RSA counterpart.

As an added advantage, Crypt::PK::RSA also supports importing/exporting
RSA keys in JWK format, which Crypt::OpenSSL::RSA does not. This might
be useful for a module dealing with JSON Web Tokens.

Signed-Off-By: Wouter Verhelst <w@uter.be>